### PR TITLE
Added missing override for parallels shared folder

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -424,6 +424,7 @@ Vagrant.configure("2") do |config|
   # uses corresponding Parallels mount options.
   config.vm.provider :parallels do |v, override|
     override.vm.synced_folder "www/", "/srv/www/", :owner => "www-data", :mount_options => []
+    override.vm.synced_folder "log/", "/var/log", :owner => "www-data", :mount_options => []
 
     vvv_config['sites'].each do |site, args|
       if args['local_dir'] != File.join(vagrant_dir, 'www', site) then


### PR DESCRIPTION
`:mount_options` for `"log/", "/var/log"` were introduced in https://github.com/Varying-Vagrant-Vagrants/VVV/commit/b132546927759ed34ca91d0b118f686acf16e6d8#diff-23b6f443c01ea2efcb4f36eedfea9089R343 but override to unset them for parallels provider was not added. This change adds this override.

Fixes #1600